### PR TITLE
getTemplateCategories ignore 1-CONTRIBUTION-GUIDE

### DIFF
--- a/src/app/quickstartLoadDialog/GithubTemplateReader.ts
+++ b/src/app/quickstartLoadDialog/GithubTemplateReader.ts
@@ -18,7 +18,7 @@ module ArmViz {
 					var categories = new Array<TemplateCategory>();
 					
 					data.forEach(item => {
-						if(item.type === 'dir') {
+						if(item.type === 'dir' && item.name !== '1-CONTRIBUTION-GUIDE') {
 							var newCategory = new TemplateCategory();
 							newCategory.name = item.name;
 							newCategory.url = item.url;


### PR DESCRIPTION
Changed the getTemplateCategories method to ignore the 1-CONTRIBUTION…-GUIDE. It's hardcoded for now, but it's important to identify a pattern in the future for other categories to ignore.