### PR TITLE
Showing error message when previewing invalid JSON

### DIFF
--- a/src/app/portalUIEditor/PortalUIEditorDialog.controller.ts
+++ b/src/app/portalUIEditor/PortalUIEditorDialog.controller.ts
@@ -40,7 +40,10 @@ module PortalUIEditor {
       try {
         obj = JSON.parse(this.json);
       } catch(err) {
-          return null;
+        this.validationResult = "Invalid JSON: " + err.toString();
+        ArmViz.Telemetry.sendEvent('PortalUIEditor', 'Preview', 'Failed: ' + err.toString());
+        
+        return null;
       }
       
       let url = 'http://armportaluiredirector.azurewebsites.net/?json=POST';


### PR DESCRIPTION
This fixed #17 

JSON in the preview window will be validated when pressing the preview button. If it is invalid, an error message will show up so that user can be notified.