### PR TITLE
.github removed from quickstart template list

### DIFF
--- a/src/app/quickstartLoadDialog/GithubTemplateReader.ts
+++ b/src/app/quickstartLoadDialog/GithubTemplateReader.ts
@@ -17,7 +17,7 @@ module ArmViz {
           var categories = new Array<TemplateCategory>();
 
           data.forEach(item => {
-            if (item.type === 'dir' && item.name !== '1-CONTRIBUTION-GUIDE') {
+            if (item.type === 'dir' && item.name !== '1-CONTRIBUTION-GUIDE' && item.name !== '.github') {
               var newCategory = new TemplateCategory();
               newCategory.name = item.name;
               newCategory.url = item.url;


### PR DESCRIPTION
This fixed issue #20 

Added an exclusion condition for the `.github` directory, which should not be in the quickstart template list.
